### PR TITLE
Raise ConnectionError with instructions if retrieval server is down

### DIFF
--- a/src/models/components/retrieval.py
+++ b/src/models/components/retrieval.py
@@ -151,7 +151,17 @@ class RetrievalClient:
             "num_images": self._num_samples,
             "num_result_ids": self._num_samples,
         }
-        response = requests.post(self._url, data=json.dumps(payload), timeout=30.0).json()
+
+        try:
+            response = requests.post(self._url, data=json.dumps(payload), timeout=30.0).json()
+        except requests.exceptions.ConnectionError:
+            raise ConnectionError(
+                "Could not connect to the retrieval server. Did you start it? "
+                "To start the server, open a terminal and run `docker compose build` "
+                "to build the docker images and then "
+                "`docker compose --profile retrieval-server up` to start the server.\n"
+                "Refer to the README for more information."
+            )
 
         formatted_response = []
         for res in response:


### PR DESCRIPTION
## What does this PR do?

Raise a ConnectionError if the retrieval server is down. Some experiments depends on an external server that must be started manually. Now, if the server is not up the client will raise a ConnectionError with instructions on how to build the Docker image and to start the container with the server.

Partially addresses #6 

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
