### PR TITLE
Improve metrics compute

### DIFF
--- a/src/models/cased.py
+++ b/src/models/cased.py
@@ -149,16 +149,6 @@ class CaSED(VocabularyFreeCLIP):
 
         self.test_outputs.append((words, targets))
 
-    def on_test_epoch_end(self) -> None:
-        """Lightning hook called at the end of the test epoch."""
-        words, targets = zip(*self.test_outputs)
-        words = sum(words, [])
-        targets = sum(targets, [])
-        self.metrics["test/semantic_metrics"](words, targets)
-        self.log_dict(self.metrics["test/semantic_metrics"])
-
-        super().on_test_epoch_end()
-
     def configure_metrics(self) -> None:
         """Configure metrics."""
         self.metrics["test/num_vocabs_avg"] = MeanMetric()

--- a/src/models/cased.py
+++ b/src/models/cased.py
@@ -2,7 +2,6 @@ from typing import Callable, Optional
 
 import torch
 import torchvision.transforms as T
-from torchmetrics import MetricCollection
 from torchmetrics.aggregation import MeanMetric
 
 from src import utils
@@ -146,6 +145,10 @@ class CaSED(VocabularyFreeCLIP):
         self.log("test/vocabs.unique", self.metrics["test/vocabs_unique"])
         self.metrics["test/vocabs/selected_unique"](sum([list(w.keys()) for w in words], []))
         self.log("test/vocabs/selected.unique", self.metrics["test/vocabs/selected_unique"])
+        self.metrics["test/semantic_iou"](words, targets)
+        self.log("test/semantic_iou", self.metrics["test/semantic_iou"])
+        self.metrics["test/semantic_similarity"](words, targets)
+        self.log("test/semantic_similarity", self.metrics["test/semantic_similarity"])
 
         self.test_outputs.append((words, targets))
 
@@ -154,13 +157,10 @@ class CaSED(VocabularyFreeCLIP):
         self.metrics["test/num_vocabs_avg"] = MeanMetric()
         self.metrics["test/vocabs_unique"] = UniqueValues()
         self.metrics["test/vocabs/selected_unique"] = UniqueValues()
-
-        semantic_metrics = {}
         semantic_cluster_acc = SemanticClusterAccuracy(task="multiclass", average="micro")
-        semantic_metrics["test/semantic_cluster_acc"] = semantic_cluster_acc
-        semantic_metrics["test/semantic_iou"] = SentenceIOU()
-        semantic_metrics["test/semantic_similarity"] = SentenceScore()
-        self.metrics["test/semantic_metrics"] = MetricCollection(semantic_metrics)
+        self.metrics["test/semantic_cluster_acc"] = semantic_cluster_acc
+        self.metrics["test/semantic_iou"] = SentenceIOU()
+        self.metrics["test/semantic_similarity"] = SentenceScore()
 
 
 if __name__ == "__main__":

--- a/src/models/components/metrics/text.py
+++ b/src/models/components/metrics/text.py
@@ -113,6 +113,8 @@ class SentenceScore(Metric):
 
         values_z = self.encoder([max(value, key=value.get) for value in values])
         targets_z = self.encoder(targets)
+        values_z = values_z.unsqueeze(0) if values_z.dim() == 1 else values_z
+        targets_z = targets_z.unsqueeze(0) if targets_z.dim() == 1 else targets_z
 
         # compute cosine similarity
         similarity = torch.nn.functional.cosine_similarity(values_z, targets_z)

--- a/src/models/vocabulary_free_clip.py
+++ b/src/models/vocabulary_free_clip.py
@@ -125,16 +125,6 @@ class VocabularyFreeCLIP(CLIP):
 
         self.test_outputs.append((words, targets))
 
-    def on_test_epoch_end(self) -> None:
-        """Lightning hook called at the end of the test epoch."""
-        words, targets = zip(*self.test_outputs)
-        words = sum(words, [])
-        targets = sum(targets, [])
-        self.metrics["test/semantic_metrics"](words, targets)
-        self.log_dict(self.metrics["test/semantic_metrics"])
-
-        super().on_test_epoch_end()
-
     def configure_metrics(self) -> None:
         """Configure metrics."""
         self.metrics["test/num_vocabs_avg"] = MeanMetric()

--- a/src/models/vocabulary_free_clip.py
+++ b/src/models/vocabulary_free_clip.py
@@ -1,5 +1,4 @@
 import torch
-from torchmetrics import MetricCollection
 from torchmetrics.aggregation import MeanMetric
 
 from src import utils
@@ -122,6 +121,10 @@ class VocabularyFreeCLIP(CLIP):
         self.log("test/vocabs.unique", self.metrics["test/vocabs_unique"])
         self.metrics["test/vocabs/selected_unique"](sum([list(w.keys()) for w in words], []))
         self.log("test/vocabs/selected.unique", self.metrics["test/vocabs/selected_unique"])
+        self.metrics["test/semantic_iou"](words, targets)
+        self.log("test/semantic_iou", self.metrics["test/semantic_iou"])
+        self.metrics["test/semantic_similarity"](words, targets)
+        self.log("test/semantic_similarity", self.metrics["test/semantic_similarity"])
 
         self.test_outputs.append((words, targets))
 
@@ -130,13 +133,10 @@ class VocabularyFreeCLIP(CLIP):
         self.metrics["test/num_vocabs_avg"] = MeanMetric()
         self.metrics["test/vocabs_unique"] = UniqueValues()
         self.metrics["test/vocabs/selected_unique"] = UniqueValues()
-
-        semantic_metrics = {}
         semantic_cluster_acc = SemanticClusterAccuracy(task="multiclass", average="micro")
-        semantic_metrics["test/semantic_cluster_acc"] = semantic_cluster_acc
-        semantic_metrics["test/semantic_iou"] = SentenceIOU()
-        semantic_metrics["test/semantic_similarity"] = SentenceScore()
-        self.metrics["test/semantic_metrics"] = MetricCollection(semantic_metrics)
+        self.metrics["test/semantic_cluster_acc"] = semantic_cluster_acc
+        self.metrics["test/semantic_iou"] = SentenceIOU()
+        self.metrics["test/semantic_similarity"] = SentenceScore()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Minor changes to metrics to (i) eval semantic similarity and semantic iou on `test_step` (avoid OOM with very large datasets and small GPUs), (ii) avoid unnecessary eval of metrics (due to model inheritance, metrics were eval multiple times), (iii) ensure the batch dim on `SentenceScore` (rare crash case with batch size 1 and only 1 vocab output).

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
